### PR TITLE
feat: ExpandDateTime convenience (datetime components)

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -94,90 +94,91 @@ quartodoc:
     - title: Core
       package: ibisml
       contents:
-      - kind: page
-        path: core
-        summary:
-          name: Common
-          desc: Core APIs
-        contents:
-          - Recipe
-          - RecipeTransform
-          - TransformResult
+        - kind: page
+          path: core
+          summary:
+            name: Common
+            desc: Core APIs
+          contents:
+            - Recipe
+            - RecipeTransform
+            - TransformResult
 
-      - kind: page
-        path: selectors
-        summary:
-          name: Selectors
-          desc: Select sets of columns by name, type, or other properties
-        contents:
-          - cols
-          - contains
-          - endswith
-          - startswith
-          - matches
-          - numeric
-          - nominal
-          - categorical
-          - string
-          - integer
-          - floating
-          - temporal
-          - date
-          - time
-          - timestamp
-          - has_type
-          - where
-          - everything
-          - selector
+        - kind: page
+          path: selectors
+          summary:
+            name: Selectors
+            desc: Select sets of columns by name, type, or other properties
+          contents:
+            - cols
+            - contains
+            - endswith
+            - startswith
+            - matches
+            - numeric
+            - nominal
+            - categorical
+            - string
+            - integer
+            - floating
+            - temporal
+            - date
+            - time
+            - timestamp
+            - has_type
+            - where
+            - everything
+            - selector
 
     - title: Steps
       desc: Define steps in a recipe
       package: ibisml
       contents:
-      - kind: page
-        path: steps-imputation
-        summary:
-          name: Imputation
-          desc: Imputation and handling of missing values
-        contents:
-          - ImputeMean
-          - ImputeMode
-          - ImputeMedian
-          - FillNA
+        - kind: page
+          path: steps-imputation
+          summary:
+            name: Imputation
+            desc: Imputation and handling of missing values
+          contents:
+            - ImputeMean
+            - ImputeMode
+            - ImputeMedian
+            - FillNA
 
-      - kind: page
-        path: steps-encoding
-        summary:
-          name: Encoding
-          desc: Encoding of categorical and string columns
-        contents:
-          - OneHotEncode
-          - CategoricalEncode
+        - kind: page
+          path: steps-encoding
+          summary:
+            name: Encoding
+            desc: Encoding of categorical and string columns
+          contents:
+            - OneHotEncode
+            - CategoricalEncode
 
-      - kind: page
-        path: steps-standardization
-        summary:
-          name: Standardization
-          desc: Standardization and normalization of numeric columns
-        contents:
-          - ScaleStandard
+        - kind: page
+          path: steps-standardization
+          summary:
+            name: Standardization
+            desc: Standardization and normalization of numeric columns
+          contents:
+            - ScaleStandard
 
-      - kind: page
-        path: steps-temporal
-        summary:
-          name: Temporal
-          desc: Feature extraction for temporal columns
-        contents:
-          - ExpandDate
-          - ExpandTime
+        - kind: page
+          path: steps-temporal
+          summary:
+            name: Temporal
+            desc: Feature extraction for temporal columns
+          contents:
+            - ExpandDateTime
+            - ExpandDate
+            - ExpandTime
 
-      - kind: page
-        path: steps-other
-        summary:
-          name: Other
-          desc: Other common tabular operations
-        contents:
-          - Cast
-          - Drop
-          - MutateAt
-          - Mutate
+        - kind: page
+          path: steps-other
+          summary:
+            name: Other
+            desc: Other common tabular operations
+          contents:
+            - Cast
+            - Drop
+            - MutateAt
+            - Mutate

--- a/ibisml/steps/__init__.py
+++ b/ibisml/steps/__init__.py
@@ -2,7 +2,7 @@ from ibisml.steps.common import Cast, Drop, MutateAt, Mutate
 from ibisml.steps.impute import FillNA, ImputeMean, ImputeMedian, ImputeMode
 from ibisml.steps.standardize import ScaleStandard
 from ibisml.steps.encode import OneHotEncode, CategoricalEncode
-from ibisml.steps.temporal import ExpandDate, ExpandTime
+from ibisml.steps.temporal import ExpandDateTime, ExpandDate, ExpandTime
 
 
 __all__ = (
@@ -17,6 +17,7 @@ __all__ = (
     "ScaleStandard",
     "OneHotEncode",
     "CategoricalEncode",
+    "ExpandDateTime",
     "ExpandDate",
     "ExpandTime",
 )

--- a/ibisml/steps/temporal.py
+++ b/ibisml/steps/temporal.py
@@ -53,35 +53,42 @@ class ExpandDateTime(Step):
     def __init__(
         self,
         inputs: SelectionType,
-        date_components: Sequence[
-            Literal["day", "week", "month", "year", "dow", "doy"]
+        datetime_components: list[
+            Literal[
+                "day",
+                "week",
+                "month",
+                "year",
+                "dow",
+                "doy",
+                "hour",
+                "minute",
+                "second",
+                "millisecond",
+            ]
         ] = (
-            "dow",
+            "day",
+            "week",
             "month",
             "year",
-        ),
-        time_components: Sequence[
-            Literal["hour", "minute", "second", "millisecond"]
-        ] = (
+            "dow",
+            "doy",
             "hour",
             "minute",
-            "second",
         ),
     ):
         self.inputs = selector(inputs)
-        self.date_components = list(date_components)
-        self.time_components = list(time_components)
+        self.datetime_components = list(datetime_components)
 
     def _repr(self) -> Iterable[tuple[str, Any]]:
         yield ("", self.inputs)
-        yield ("date_components", self.date_components)
-        yield ("time_components", self.time_components)
+        yield ("datetime_components", self.datetime_components)
 
     def fit(self, table: ir.Table, metadata: Metadata) -> Transform:
-        date_columns = self.inputs.select_columns(table, metadata)
+        columns = self.inputs.select_columns(table, metadata)
 
-        if "month" in self.date_components:
-            for col in date_columns:
+        if "month" in self.datetime_components:
+            for col in columns:
                 metadata.set_categories(
                     f"{col}_month",
                     [
@@ -99,8 +106,8 @@ class ExpandDateTime(Step):
                         "December",
                     ],
                 )
-        if "dow" in self.date_components:
-            for col in date_columns:
+        if "dow" in self.datetime_components:
+            for col in columns:
                 metadata.set_categories(
                     f"{col}_dow",
                     [
@@ -114,10 +121,7 @@ class ExpandDateTime(Step):
                     ],
                 )
 
-        time_columns = self.inputs.select_columns(table, metadata)
-        return ml.transforms.ExpandDateTime(
-            date_columns, self.date_components, time_columns, self.time_components
-        )
+        return ml.transforms.ExpandDateTime(columns, self.datetime_components)
 
 
 class ExpandDate(Step):

--- a/ibisml/transforms/__init__.py
+++ b/ibisml/transforms/__init__.py
@@ -2,7 +2,7 @@ from ibisml.transforms.common import Cast, Drop, MutateAt, Mutate
 from ibisml.transforms.impute import FillNA
 from ibisml.transforms.standardize import ScaleStandard
 from ibisml.transforms.encode import OneHotEncode, CategoricalEncode
-from ibisml.transforms.temporal import ExpandDate, ExpandTime
+from ibisml.transforms.temporal import ExpandDateTime, ExpandDate, ExpandTime
 
 __all__ = (
     "Cast",
@@ -13,6 +13,7 @@ __all__ = (
     "ScaleStandard",
     "OneHotEncode",
     "CategoricalEncode",
+    "ExpandDateTime",
     "ExpandDate",
     "ExpandTime",
 )

--- a/ibisml/transforms/temporal.py
+++ b/ibisml/transforms/temporal.py
@@ -10,26 +10,44 @@ import ibis.expr.types as ir
 class ExpandDateTime(Transform):
     def __init__(
         self,
-        date_columns: list[str],
-        date_components: list[Literal["day", "week", "month", "year", "dow", "doy"]],
-        time_columns: list[str],
-        time_components: list[Literal["hour", "minute", "second", "millisecond"]],
+        datetime_columns: list[str],
+        datetime_components: list[
+            Literal[
+                "day",
+                "week",
+                "month",
+                "year",
+                "dow",
+                "doy",
+                "hour",
+                "minute",
+                "second",
+                "millisecond",
+            ]
+        ] = (
+            "day",
+            "week",
+            "month",
+            "year",
+            "dow",
+            "doy",
+            "hour",
+            "minute",
+        ),
     ):
-        self.date_columns = date_columns
-        self.date_components = date_components
-        self.time_columns = time_columns
-        self.time_components = time_components
+        self.datetime_columns = datetime_columns
+        self.datetime_components = datetime_components
 
     @property
     def input_columns(self) -> list[str]:
-        return self.date_columns + self.time_columns
+        return self.datetime_columns
 
     def transform(self, table: ir.Table) -> ir.Table:
         new_cols = []
 
-        for name in self.date_columns:
+        for name in self.datetime_columns:
             col = table[name]
-            for comp in self.date_components:
+            for comp in self.datetime_components:
                 if comp == "day":
                     feat = col.day()
                 elif comp == "week":
@@ -42,12 +60,7 @@ class ExpandDateTime(Transform):
                     feat = col.day_of_week.index()
                 elif comp == "doy":
                     feat = col.day_of_year()
-                new_cols.append(feat.name(f"{name}_{comp}"))
-
-        for name in self.time_columns:
-            col = table[name]
-            for comp in self.time_components:
-                if comp == "hour":
+                elif comp == "hour":
                     feat = col.hour()
                 elif comp == "minute":
                     feat = col.minute()

--- a/ibisml/transforms/temporal.py
+++ b/ibisml/transforms/temporal.py
@@ -7,6 +7,59 @@ from ibisml.core import Transform
 import ibis.expr.types as ir
 
 
+class ExpandDateTime(Transform):
+    def __init__(
+        self,
+        date_columns: list[str],
+        date_components: list[Literal["day", "week", "month", "year", "dow", "doy"]],
+        time_columns: list[str],
+        time_components: list[Literal["hour", "minute", "second", "millisecond"]],
+    ):
+        self.date_columns = date_columns
+        self.date_components = date_components
+        self.time_columns = time_columns
+        self.time_components = time_components
+
+    @property
+    def input_columns(self) -> list[str]:
+        return self.date_columns + self.time_columns
+
+    def transform(self, table: ir.Table) -> ir.Table:
+        new_cols = []
+
+        for name in self.date_columns:
+            col = table[name]
+            for comp in self.date_components:
+                if comp == "day":
+                    feat = col.day()
+                elif comp == "week":
+                    feat = col.week_of_year()
+                elif comp == "month":
+                    feat = col.month() - 1
+                elif comp == "year":
+                    feat = col.year()
+                elif comp == "dow":
+                    feat = col.day_of_week.index()
+                elif comp == "doy":
+                    feat = col.day_of_year()
+                new_cols.append(feat.name(f"{name}_{comp}"))
+
+        for name in self.time_columns:
+            col = table[name]
+            for comp in self.time_components:
+                if comp == "hour":
+                    feat = col.hour()
+                elif comp == "minute":
+                    feat = col.minute()
+                elif comp == "second":
+                    feat = col.second()
+                elif comp == "millisecond":
+                    feat = col.millisecond()
+                new_cols.append(feat.name(f"{name}_{comp}"))
+
+        return table.mutate(new_cols)
+
+
 class ExpandDate(Transform):
     def __init__(
         self,

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -66,3 +66,28 @@ def test_expand_time():
         x_millisecond=_.x.millisecond(),
     )
     assert res.equals(sol)
+
+
+def test_expand_datetime():
+    t = ibis.table({"y": "timestamp", "z": "int"})
+    step = ml.ExpandDateTime(
+        ml.timestamp(),
+        date_components=["dow", "doy", "day", "week", "month", "year"],
+        time_components=["hour", "minute", "second", "millisecond"],
+    )
+    transform = step.fit(t, ml.core.Metadata())
+
+    res = transform.transform(t)
+    sol = t.mutate(
+        y_dow=_.y.day_of_week.index(),
+        y_doy=_.y.day_of_year(),
+        y_day=_.y.day(),
+        y_week=_.y.week_of_year(),
+        y_month=_.y.month() - 1,
+        y_year=_.y.year(),
+        y_hour=_.y.hour(),
+        y_minute=_.y.minute(),
+        y_second=_.y.second(),
+        y_millisecond=_.y.millisecond(),
+    )
+    assert res.equals(sol)

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -72,8 +72,18 @@ def test_expand_datetime():
     t = ibis.table({"y": "timestamp", "z": "int"})
     step = ml.ExpandDateTime(
         ml.timestamp(),
-        date_components=["dow", "doy", "day", "week", "month", "year"],
-        time_components=["hour", "minute", "second", "millisecond"],
+        datetime_components=[
+            "dow",
+            "doy",
+            "day",
+            "week",
+            "month",
+            "year",
+            "hour",
+            "minute",
+            "second",
+            "millisecond",
+        ],
     )
     transform = step.fit(t, ml.core.Metadata())
 


### PR DESCRIPTION
Closes #14, this is a recreation of #15, which I will close tomorrow. 

The test has been updated as well. This is how I have been using it to try this out, similar to the previous PR. 

```
from ibis.interactive import *
import ibisml as ml

con = ibis.duckdb.connect()

t = con.sql("select get_current_timestamp() AS datetime")
step = ml.ExpandDateTime("datetime")
transform = step.fit(t, ml.core.Metadata())
res = transform.transform(t)
res
```

When no literal values are passed to the components on the return, all columns except second and millisecond are chosen.