### PR TITLE
feat(steps): implement a step to count encode cols

### DIFF
--- a/ibisml/select.py
+++ b/ibisml/select.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Collection
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Callable, ClassVar, Union
 
 import ibis.expr.datatypes as dt
@@ -73,7 +73,7 @@ class Selector:
         ]
 
 
-SelectionType = Union[str, Collection[str], Callable[[ir.Column], bool], Selector]
+SelectionType = Union[str, Iterable[str], Callable[[ir.Column], bool], Selector]
 
 
 def selector(obj: SelectionType) -> Selector:
@@ -82,7 +82,7 @@ def selector(obj: SelectionType) -> Selector:
         return obj
     elif isinstance(obj, str):
         return cols(obj)
-    elif isinstance(obj, Collection):
+    elif isinstance(obj, Iterable):
         return cols(*obj)
     elif callable(obj):
         return where(obj)

--- a/ibisml/steps/__init__.py
+++ b/ibisml/steps/__init__.py
@@ -1,5 +1,5 @@
 from ibisml.steps.common import Cast, Drop, Mutate, MutateAt
-from ibisml.steps.encode import CategoricalEncode, OneHotEncode
+from ibisml.steps.encode import CategoricalEncode, CountEncode, OneHotEncode
 from ibisml.steps.impute import FillNA, ImputeMean, ImputeMedian, ImputeMode
 from ibisml.steps.standardize import ScaleMinMax, ScaleStandard
 from ibisml.steps.temporal import ExpandDate, ExpandDateTime, ExpandTime
@@ -7,6 +7,7 @@ from ibisml.steps.temporal import ExpandDate, ExpandDateTime, ExpandTime
 __all__ = (
     "Cast",
     "CategoricalEncode",
+    "CountEncode",
     "Drop",
     "ExpandDate",
     "ExpandDateTime",

--- a/ibisml/steps/encode.py
+++ b/ibisml/steps/encode.py
@@ -286,6 +286,6 @@ class CountEncode(Step):
                 {c: f"{c}_count"}
             )
 
-        fillna = FillNA(list(self.value_counts_), 0)
+        fillna = FillNA(self.value_counts_, 0)
         fillna.fit_table(table, Metadata())
         return fillna.transform_table(table)

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -1,0 +1,40 @@
+import ibis
+import pandas as pd
+
+import ibisml as ml
+
+
+def test_count_encode():
+    t_train = ibis.memtable(
+        {
+            "time": [
+                pd.Timestamp("2016-05-25 13:30:00.023"),
+                pd.Timestamp("2016-05-25 13:30:00.023"),
+                pd.Timestamp("2016-05-25 13:30:00.030"),
+                pd.Timestamp("2016-05-25 13:30:00.041"),
+                pd.Timestamp("2016-05-25 13:30:00.048"),
+                pd.Timestamp("2016-05-25 13:30:00.049"),
+                pd.Timestamp("2016-05-25 13:30:00.072"),
+                pd.Timestamp("2016-05-25 13:30:00.075"),
+            ],
+            "ticker": ["GOOG", "MSFT", "MSFT", "MSFT", None, "AAPL", "GOOG", "MSFT"],
+        }
+    )
+    t_test = ibis.memtable(
+        {
+            "time": [
+                pd.Timestamp("2016-05-25 13:30:00.023"),
+                pd.Timestamp("2016-05-25 13:30:00.038"),
+                pd.Timestamp("2016-05-25 13:30:00.048"),
+                pd.Timestamp("2016-05-25 13:30:00.049"),
+                pd.Timestamp("2016-05-25 13:30:00.050"),
+                pd.Timestamp("2016-05-25 13:30:00.051"),
+            ],
+            "ticker": ["MSFT", "MSFT", "GOOG", "GOOG", "AMZN", None],
+        }
+    )
+
+    step = ml.CountEncode("ticker")
+    step.fit_table(t_train, ml.core.Metadata())
+    res = step.transform_table(t_test)
+    assert res.to_pandas().sort_values(by="time").ticker.to_list() == [4, 4, 2, 2, 0, 0]


### PR DESCRIPTION
Required for https://nvidia-merlin.github.io/NVTabular/v1.0.0/examples/winning-solution-recsys2020-twitter/01-02-04-Download-Convert-ETL-with-NVTabular-Training-with-XGBoost.html.

Based on https://github.com/rapidsai/deeplearning/blob/main/RecSys2020Tutorial/03_4_CountEncoding.ipynb.

I don't treat nulls as a meaningful unknown value; to get counts for nulls, add a step like `FillNA("UNKNOWN")` first.