### PR TITLE
Plumb through `y` in `fit` and `fit_transform`

### DIFF
--- a/ibisml/select.py
+++ b/ibisml/select.py
@@ -69,7 +69,7 @@ class Selector:
         return [
             c
             for c in table.columns
-            if self.matches(table[c], metadata)  # type: ignore
+            if c not in metadata.targets and self.matches(table[c], metadata)  # type: ignore
         ]
 
 

--- a/ibisml/steps/encode.py
+++ b/ibisml/steps/encode.py
@@ -133,7 +133,7 @@ class OneHotEncode(Step):
         to_compute = []
         for column in columns:
             if cats := metadata.get_categories(column):
-                categories[column] = list(range(len(cats.values)))
+                categories[column] = list(range(len(cats)))
             else:
                 to_compute.append(column)
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -6,7 +6,7 @@ import ibisml as ml
 
 
 def eval_select(selector):
-    metadata = ml.core.Metadata()
+    metadata = ml.core.Metadata(targets=("y",))
     metadata.set_categories("a_categorical", ["a", "b"])
     metadata.set_categories("b_categorical", ["c", "d"])
 
@@ -20,6 +20,7 @@ def eval_select(selector):
             "b_time": "time",
             "b_date": "date",
             "b_timestamp": "timestamp",
+            "y": "int",
         }
     )
 


### PR DESCRIPTION
Previously all steps would only rely on `X` during fitting, so we completely ignored `y` if it was passed in. We now have at least one desired `Step` that relies on `y` during the fitting process, which means we need to start properly handling `y` in `fit`/`fit_transform`.

This PR handles:
- normalizing `X` and `y` to a single `Table` from a variety of possible inputs
- Plumbing through `X` and `y` metadata through `fit` and `fit_transform`.

~Still needs a bunch of tests, but I believe this works already in general.~