### PR TITLE
feat(core): implement `Recipe` and `Step` printing

### DIFF
--- a/ibis_ml/__init__.py
+++ b/ibis_ml/__init__.py
@@ -1,5 +1,7 @@
 """IbisML is a library for building scalable ML pipelines using Ibis."""
 
+import pprint
+
 from ibis_ml.core import Recipe, Step
 from ibis_ml.select import (
     categorical,
@@ -23,8 +25,11 @@ from ibis_ml.select import (
     where,
 )
 from ibis_ml.steps import *
+from ibis_ml.utils._pprint import _pprint_recipe
 
 from ._version import __version__
+
+pprint.PrettyPrinter._dispatch[Recipe.__repr__] = _pprint_recipe  # noqa: SLF001
 
 
 def _auto_patch_skorch() -> None:

--- a/ibis_ml/__init__.py
+++ b/ibis_ml/__init__.py
@@ -25,11 +25,13 @@ from ibis_ml.select import (
     where,
 )
 from ibis_ml.steps import *
-from ibis_ml.utils._pprint import _pprint_recipe
+from ibis_ml.utils._pprint import _pprint_recipe, _pprint_step, _safe_repr
 
 from ._version import __version__
 
 pprint.PrettyPrinter._dispatch[Recipe.__repr__] = _pprint_recipe  # noqa: SLF001
+pprint.PrettyPrinter._dispatch[Step.__repr__] = _pprint_step  # noqa: SLF001
+pprint.PrettyPrinter._safe_repr = _safe_repr  # noqa: SLF001
 
 
 def _auto_patch_skorch() -> None:

--- a/ibis_ml/__init__.py
+++ b/ibis_ml/__init__.py
@@ -29,11 +29,13 @@ from ibis_ml.utils._pprint import _pprint_recipe, _pprint_step, _safe_repr
 
 from ._version import __version__
 
+# Add support for `Recipe`s and `Step`s to the built-in `PrettyPrinter`.
 pprint.PrettyPrinter._dispatch[Recipe.__repr__] = _pprint_recipe  # noqa: SLF001
 pprint.PrettyPrinter._dispatch[Step.__repr__] = _pprint_step  # noqa: SLF001
 pprint.PrettyPrinter._safe_repr = _safe_repr  # noqa: SLF001
 
 
+# Patch `skorch` since it does not support the array interface protocol.
 def _auto_patch_skorch() -> None:
     try:
         import skorch.net

--- a/ibis_ml/core.py
+++ b/ibis_ml/core.py
@@ -340,6 +340,9 @@ class Recipe:
         self.steps = steps
         self._output_format = "default"
 
+    def __repr__(self):
+        return f"Recipe({', '.join(repr(step) for step in self.steps)})"
+
     @property
     def output_format(self) -> Literal["default", "pandas", "pyarrow", "polars"]:
         """The output format to use for ``transform``"""

--- a/ibis_ml/core.py
+++ b/ibis_ml/core.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import os
+import pprint
 from collections import defaultdict
 from collections.abc import Iterable, Sequence
 from functools import cache
@@ -283,6 +284,9 @@ def _get_categorize_chunk() -> Callable[[str, list[str], Any], pd.DataFrame]:
 
 
 class Step:
+    def __repr__(self):
+        return pprint.pformat(self)
+
     def fit_table(self, table: ir.Table, metadata: Metadata) -> None:
         pass
 
@@ -341,7 +345,7 @@ class Recipe:
         self._output_format = "default"
 
     def __repr__(self):
-        return f"Recipe({', '.join(repr(step) for step in self.steps)})"
+        return pprint.pformat(self)
 
     @property
     def output_format(self) -> Literal["default", "pandas", "pyarrow", "polars"]:

--- a/ibis_ml/utils/_pprint.py
+++ b/ibis_ml/utils/_pprint.py
@@ -37,6 +37,7 @@ def _pprint_step(self, object, stream, indent, allowance, context, level):
             next_ent = next(it)
         except StopIteration:
             last = True
+        # TODO(deepyaman): Support `compact` option for `PrettyPrinter`.
         stream.write(delim)
         delim = delimnl
         k, v = ent
@@ -61,7 +62,17 @@ def _pprint_step(self, object, stream, indent, allowance, context, level):
 
 
 def _safe_repr(self, object, context, maxlevels, level):
-    # Return triple (repr_string, isreadable, isrecursive).
+    """Return triple (repr_string, isreadable, isrecursive).
+
+    Notes
+    -----
+    Same as the built-in ``pprint.PrettyPrinter._safe_repr``, with added
+    support for ``Recipe`` and ``Step`` objects.
+
+    References
+    ----------
+    .. [1] https://github.com/python/cpython/blob/3.12/Lib/pprint.py#L554-L633
+    """
     typ = type(object)
     if typ in pprint._builtin_scalars:  # noqa: SLF001
         return repr(object), True, False

--- a/ibis_ml/utils/_pprint.py
+++ b/ibis_ml/utils/_pprint.py
@@ -1,0 +1,18 @@
+def _pprint_recipe(self, object, stream, indent, allowance, context, level):
+    stream.write(object.__class__.__name__ + "(")
+    if getattr(self, "_indent_at_name", True):
+        indent += len(object.__class__.__name__)
+
+    # TODO(deepyaman): Format parameters (beyond `steps`) more robustly.
+    indent += self._indent_per_level
+    k, v = "steps", list(object.steps)
+    rep = self._repr(k, context, level)
+    rep = rep.strip("'")
+    middle = "="
+    stream.write(rep)
+    stream.write(middle)
+    self._format(
+        v, stream, indent + len(rep) + len(middle), allowance + 1, context, level
+    )
+
+    stream.write(")")

--- a/ibis_ml/utils/_pprint.py
+++ b/ibis_ml/utils/_pprint.py
@@ -8,18 +8,7 @@ def _pprint_recipe(self, object, stream, indent, allowance, context, level):
     if getattr(self, "_indent_at_name", True):
         indent += len(object.__class__.__name__)
 
-    # TODO(deepyaman): Format parameters (beyond `steps`) more robustly.
-    indent += self._indent_per_level
-    k, v = "steps", list(object.steps)
-    rep = self._repr(k, context, level)
-    rep = rep.strip("'")
-    middle = "="
-    stream.write(rep)
-    stream.write(middle)
-    self._format(
-        v, stream, indent + len(rep) + len(middle), allowance + 1, context, level
-    )
-
+    self._format_items(object.steps, stream, indent, allowance + 1, context, level)
     stream.write(")")
 
 
@@ -150,7 +139,7 @@ def _safe_repr(self, object, context, maxlevels, level):
     if issubclass(typ, Recipe) and r is Recipe.__repr__:
         objid = id(object)
         if maxlevels and level >= maxlevels:
-            return f"{typ.__name__}(steps=[...])", False, objid in context
+            return f"{typ.__name__}(...)", False, objid in context
         if objid in context:
             return pprint._recursion(object), False, True  # noqa: SLF001
         context[objid] = 1
@@ -167,7 +156,7 @@ def _safe_repr(self, object, context, maxlevels, level):
             if orecur:
                 recursive = True
         del context[objid]
-        return f"{typ.__name__}(steps=[{', '.join(components)}])", readable, recursive
+        return f"{typ.__name__}({', '.join(components)})", readable, recursive
 
     if issubclass(typ, Step) and r is Step.__repr__:
         objid = id(object)

--- a/ibis_ml/utils/_pprint.py
+++ b/ibis_ml/utils/_pprint.py
@@ -1,3 +1,8 @@
+import pprint
+
+from ibis_ml.core import Recipe, Step
+
+
 def _pprint_recipe(self, object, stream, indent, allowance, context, level):
     stream.write(object.__class__.__name__ + "(")
     if getattr(self, "_indent_at_name", True):
@@ -16,3 +21,182 @@ def _pprint_recipe(self, object, stream, indent, allowance, context, level):
     )
 
     stream.write(")")
+
+
+def _pprint_step(self, object, stream, indent, allowance, context, level):
+    stream.write(object.__class__.__name__ + "(")
+    if getattr(self, "_indent_at_name", True):
+        indent += len(object.__class__.__name__)
+
+    indent += self._indent_per_level
+    delimnl = ",\n" + " " * indent
+    delim = ""
+    it = object._repr()  # noqa: SLF001
+    try:
+        next_ent = next(it)
+    except StopIteration:
+        return
+    last = False
+    n_items = 0
+    while not last:
+        if n_items == getattr(self, "n_max_elements_to_show", None):
+            stream.write(", ...")
+            break
+        n_items += 1
+        ent = next_ent
+        try:
+            next_ent = next(it)
+        except StopIteration:
+            last = True
+        stream.write(delim)
+        delim = delimnl
+        k, v = ent
+        if k:
+            rep = self._repr(k, context, level)
+            rep = rep.strip("'")
+            middle = "="
+            stream.write(rep)
+            stream.write(middle)
+        else:
+            rep = middle = ""
+        self._format(
+            v,
+            stream,
+            indent + len(rep) + len(middle),
+            allowance + 1 if last else 1,
+            context,
+            level,
+        )
+
+    stream.write(")")
+
+
+def _safe_repr(self, object, context, maxlevels, level):
+    # Return triple (repr_string, isreadable, isrecursive).
+    typ = type(object)
+    if typ in pprint._builtin_scalars:  # noqa: SLF001
+        return repr(object), True, False
+
+    r = getattr(typ, "__repr__", None)
+
+    if issubclass(typ, int) and r is int.__repr__:
+        if self._underscore_numbers:
+            return f"{object:_d}", True, False
+        else:
+            return repr(object), True, False
+
+    if issubclass(typ, dict) and r is dict.__repr__:
+        if not object:
+            return "{}", True, False
+        objid = id(object)
+        if maxlevels and level >= maxlevels:
+            return "{...}", False, objid in context
+        if objid in context:
+            return pprint._recursion(object), False, True  # noqa: SLF001
+        context[objid] = 1
+        readable = True
+        recursive = False
+        components = []
+        append = components.append
+        level += 1
+        if self._sort_dicts:
+            items = sorted(object.items(), key=pprint._safe_tuple)  # noqa: SLF001
+        else:
+            items = object.items()
+        for k, v in items:
+            krepr, kreadable, krecur = self.format(k, context, maxlevels, level)
+            vrepr, vreadable, vrecur = self.format(v, context, maxlevels, level)
+            append("%s: %s" % (krepr, vrepr))  # noqa: UP031
+            readable = readable and kreadable and vreadable
+            if krecur or vrecur:
+                recursive = True
+        del context[objid]
+        return "{%s}" % ", ".join(components), readable, recursive
+
+    if (issubclass(typ, list) and r is list.__repr__) or (
+        issubclass(typ, tuple) and r is tuple.__repr__
+    ):
+        if issubclass(typ, list):
+            if not object:
+                return "[]", True, False
+            format = "[%s]"
+        elif len(object) == 1:
+            format = "(%s,)"
+        else:
+            if not object:
+                return "()", True, False
+            format = "(%s)"
+        objid = id(object)
+        if maxlevels and level >= maxlevels:
+            return format % "...", False, objid in context
+        if objid in context:
+            return pprint._recursion(object), False, True  # noqa: SLF001
+        context[objid] = 1
+        readable = True
+        recursive = False
+        components = []
+        append = components.append
+        level += 1
+        for o in object:
+            orepr, oreadable, orecur = self.format(o, context, maxlevels, level)
+            append(orepr)
+            if not oreadable:
+                readable = False
+            if orecur:
+                recursive = True
+        del context[objid]
+        return format % ", ".join(components), readable, recursive
+
+    if issubclass(typ, Recipe) and r is Recipe.__repr__:
+        objid = id(object)
+        if maxlevels and level >= maxlevels:
+            return f"{typ.__name__}(steps=[...])", False, objid in context
+        if objid in context:
+            return pprint._recursion(object), False, True  # noqa: SLF001
+        context[objid] = 1
+        readable = True
+        recursive = False
+        components = []
+        append = components.append
+        level += 1
+        for o in object.steps:
+            orepr, oreadable, orecur = self.format(o, context, maxlevels, level)
+            append(orepr)
+            if not oreadable:
+                readable = False
+            if orecur:
+                recursive = True
+        del context[objid]
+        return f"{typ.__name__}(steps=[{', '.join(components)}])", readable, recursive
+
+    if issubclass(typ, Step) and r is Step.__repr__:
+        objid = id(object)
+        if maxlevels and level >= maxlevels:
+            return f"{typ.__name__}(...)", False, objid in context
+        if objid in context:
+            return pprint._recursion(object), False, True  # noqa: SLF001
+        context[objid] = 1
+        readable = True
+        recursive = False
+        components = []
+        append = components.append
+        level += 1
+        items = object._repr()  # noqa: SLF001
+        for k, v in items:
+            if k:
+                krepr, kreadable, krecur = self.format(k, context, maxlevels, level)
+                krepr = krepr.strip("'")
+                middle = "="
+            else:
+                krepr, kreadable, krecur = "", True, False
+                middle = ""
+            vrepr, vreadable, vrecur = self.format(v, context, maxlevels, level)
+            append(f"{krepr}{middle}{vrepr}")
+            readable = readable and kreadable and vreadable
+            if krecur or vrecur:
+                recursive = True
+        del context[objid]
+        return f"{typ.__name__}({', '.join(components)})", readable, recursive
+
+    rep = repr(object)
+    return rep, (rep and not rep.startswith("<")), False

--- a/tests/test_pprint.py
+++ b/tests/test_pprint.py
@@ -1,0 +1,52 @@
+import pytest
+
+import ibis_ml as ml
+
+
+@pytest.fixture()
+def rec():
+    imputer = ml.ImputeMean(ml.numeric())
+    scaler = ml.ScaleStandard(ml.numeric())
+    encoder = ml.OneHotEncode(ml.string(), min_frequency=20, max_categories=10)
+    return ml.Recipe(imputer, scaler, encoder)
+
+
+@pytest.fixture()
+def pipe(rec):
+    pytest.importorskip("sklearn")
+    from sklearn.pipeline import Pipeline
+    from sklearn.svm import SVC
+
+    return Pipeline([("rec", rec), ("svc", SVC())])
+
+
+def test_steps(rec):
+    expected = [
+        "ImputeMean(numeric())",
+        "ScaleStandard(numeric())",
+        "OneHotEncode(string(), min_frequency=20, max_categories=10)",
+    ]
+    assert [repr(step) for step in rec.steps] == expected
+
+
+def test_recipe(rec):
+    expected = """
+Recipe(ImputeMean(numeric()),
+       ScaleStandard(numeric()),
+       OneHotEncode(string(), min_frequency=20, max_categories=10))"""
+
+    expected = expected[1:]  # remove first \n
+    assert repr(rec) == expected
+
+
+def test_recipe_in_sklearn_pipeline(pipe):
+    expected = """
+Pipeline(steps=[('rec',
+                 Recipe(ImputeMean(numeric()), ScaleStandard(numeric()),
+                        OneHotEncode(string(),
+                                     min_frequency=20,
+                                     max_categories=10))),
+                ('svc', SVC())])"""
+
+    expected = expected[1:]  # remove first \n
+    assert repr(pipe) == expected


### PR DESCRIPTION
To test:

```pycon
>>> # Create test pipeline
>>> from sklearn.feature_selection import SelectKBest
>>> from sklearn.pipeline import Pipeline
>>> from sklearn.svm import SVC
>>> import ibis_ml as ml
>>> 
>>> imputer = ml.ImputeMean(ml.numeric())
>>> scaler = ml.ScaleStandard(ml.numeric())
>>> rec = ml.Recipe(imputer, scaler)
>>> subpipe = Pipeline(steps=[("select", SelectKBest(k=2)), ("svc", SVC())])
>>> pipe = Pipeline([("rec", rec), ("sub", subpipe)])
>>> 
>>> # Pretty-print pipeline
>>> from sklearn.utils._pprint import _EstimatorPrettyPrinter
>>> 
>>> # Default behavior (indent at name) looks OK
>>> pp = _EstimatorPrettyPrinter(compact=False, indent=1, indent_at_name=True)
>>> print(pp.pformat(pipe))
Pipeline(steps=[('rec',
                 Recipe(ImputeMean(numeric()), ScaleStandard(numeric()))),
                ('sub',
                 Pipeline(steps=[('select', SelectKBest(k=2)),
                                 ('svc', SVC())]))])
>>>
>>> # `indent_at_name=False` looks like it also works
>>> pp = _EstimatorPrettyPrinter(compact=False, indent=1, indent_at_name=False)
>>> print(pp.pformat(pipe))
Pipeline(steps=[('rec', Recipe(ImputeMean(numeric()), ScaleStandard(numeric()))),
        ('sub',
         Pipeline(steps=[('select', SelectKBest(k=2)), ('svc', SVC())]))])
```